### PR TITLE
Add the ability to resize the left sidebar.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -26,6 +26,7 @@
 			<div id='not_gantt_container'>
 				<div id='not_gantt_not_magic'>
 					<div id='sidebar_left'></div>
+					<div id="sidebar_spacer"></div>
 
 					<div id='main_nav'>
 

--- a/src/interface/ModelsSidebar.js
+++ b/src/interface/ModelsSidebar.js
@@ -2,14 +2,44 @@ $( document ).ready(function() {
     G.modelsSidebar = new ModelsSidebar("");
 });
 
+const MAX_SIDEBAR_WIDTH = 500;
+const MIN_SIDEBAR_WIDTH = 20;
+
 class ModelsSidebar {
 	constructor(selected) {
 		this.showSelected = this.showSelected.bind(this);
 		this.selectedPath = selected;
+		this.resizing = false;
 		
 		this.buildSideBar();
+		this.enableSideBarResize();
 	}
 
+	enableSideBarResize() {
+		function resizeHandler(event) {
+			if (event.pageX >= MIN_SIDEBAR_WIDTH && event.pageX <= MAX_SIDEBAR_WIDTH) {
+				// Because of the magic of CSS variables, all we have to do is update the sidebar-left-width
+				// Check the calculations in main.css to see how everything else is calculated based on this.
+				const html = document.getElementsByTagName('html')[0];
+				html.style.cssText = `--sidebar-left-width: ${event.pageX}px`;
+			}
+		}
+
+		// On mousedown on the spacer, set indicator that we are resizing the sidebar and bind the resizing handler.
+		$('#sidebar_spacer').on('mousedown', function() {
+			G.modelsSidebar.resizing = true;
+			$(document).on('mousemove', resizeHandler);
+		})
+
+		// Mouseup could happen anywhere, so check that on the document.
+		// If there's a mouseup and we're resizing, stop the resizing handler.
+		$(document).on('mouseup', function() {
+			if (G.modelsSidebar.resizing) {
+				G.modelsSidebar.resizing = false;
+				$(document).off('mousemove', resizeHandler);
+			}
+		})
+	}
 		
 	buildSideBar() {
 		$( '#sidebar_left' ).empty();

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -124,7 +124,6 @@
 #main_nav {
 	position:absolute;
 	top:0px;
-	/* TODO: resize */
 	left: calc(var(--sidebar-left-width) + var(--sidebar-spacer-width) + 10px); 
 	width: calc(100% - var(--sidebar-left-width) - var(--sidebar-spacer-width) - var(--sidebar-right-width) - 30px);
 	height:59px;

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -19,7 +19,12 @@
     --gantt-text-shadow-color: #FFF; 
     --gantt-border-color: #CCC; 
     --windows-menu-font-color: #000; 
-    --magic-button-background: #F8F8F8; 
+	--magic-button-background: #F8F8F8; 
+	
+	--gutter-width: 40px;
+	--sidebar-spacer-width: 3px;
+	--sidebar-left-width: 190px;
+	--sidebar-right-width: 30px;
 }
 
 
@@ -84,6 +89,7 @@
 	float:left;
 	width:100%;
 	height:100%;
+	display:flex;
 }
 
 #not_gantt_but_is_magic {
@@ -96,22 +102,31 @@
 }
 
 #sidebar_left {
-	position:absolute;
-	top:0px;
-	left:0px;
-	width:192px;
+	width: var(--sidebar-left-width);
 	height:100%;
 	background-color:var(--sidebar-left-bg-color);
 	overflow-y:auto;
 	overflow-x:hidden;
 }
 
+#sidebar_spacer {
+	background: transparent;
+	height: 100%;
+	width: var(--sidebar-spacer-width);
+	cursor: col-resize
+}
+
+#sidebar_spacer:hover {
+	background: var(--model-select-bg-color);
+}
+
 
 #main_nav {
 	position:absolute;
 	top:0px;
-	left:203px;
-	width: calc(100% - 190px - 55px);
+	/* TODO: resize */
+	left: calc(var(--sidebar-left-width) + var(--sidebar-spacer-width) + 10px); 
+	width: calc(100% - var(--sidebar-left-width) - var(--sidebar-spacer-width) - var(--sidebar-right-width) - 30px);
 	height:59px;
 	border-bottom: 1px solid;
 	border-color:var(--border-color);
@@ -160,8 +175,8 @@
 	font-size: 16px;
 	position:absolute;
 	top:60px;
-	left:192px;
-	width: 40px;
+	left: calc(var(--sidebar-left-width) + var(--sidebar-spacer-width));
+	width: var(--gutter-width);
 	height:calc(100% - 60px);
 /*	background-color:var(--main-bg-color);*/
 	overflow: hidden;
@@ -173,8 +188,9 @@
 	font-size: 16px;
 	position:absolute;
 	top:60px;
-	left:232px;
-	width: calc(100% - 190px - 30px - 40px - 5px); /*5px for custom scroll bar width*/
+	left: calc(var(--sidebar-left-width) + var(--sidebar-spacer-width) + var(--gutter-width));
+	/* 5px is for padding to right of scrollbar */
+	width: calc(100% - var(--sidebar-left-width) - var(--sidebar-spacer-width) - var(--gutter-width) - var(--sidebar-right-width) - 5px);
 	height:calc(100% - 60px);
 	background-color:var(--main-bg-color);
 }
@@ -219,7 +235,7 @@
 	position:absolute;
 	top:0px;
 	right:0px;
-	width:30px;
+	width:var(--sidebar-right-width);
 	height:100%;
 	background-color:var(--sidebar-right-bg-color);
 }

--- a/src/style/sidebar.css
+++ b/src/style/sidebar.css
@@ -51,7 +51,6 @@
 .model_label {
 	position: absolute;
 	left:20px;
-	width:157px;
 	height:26px;
 	line-height: 26px;
 }
@@ -84,8 +83,10 @@ input[type=text].rename_model:focus {
 	border-bottom: 13px solid transparent; 
 	border-right:15px solid var(--main-bg-color); 
 	
-}.model_pointer_container {
+}
+
+.model_pointer_container {
 	position: absolute;
-	left:177px;
-	width:15px;
+	width: 15px;
+	right: 0;
 }


### PR DESCRIPTION
Basically I added a `sidebar_spacer` that is 2px wide. In `ModelsSidebar.js` is the logic to handle the resizing. When you mousedown on the spacer, it starts listening for a mouse move and adjusts the width of the sidebar. Then when you mouseup, it stops listening for the mousemove.

Then I adjusted main.css so that everything else (like main_nav and gutter) does a `calc()` based on the width of the left sidebar. That way the only thing that ModelsSidebar.js needs to do is adjust the `--sidebar-left-width` css variable. Then the position/width of everything else automagically adjusts around that in realtime.

Edit: I should note that it doesn't persist the width of the sidebar if you close the app. It'll reset back to 190px next time you start. We can store this in a config if that's a big deal.

![Screen Recording 2020-08-03 at 4 27 33 PM](https://user-images.githubusercontent.com/173666/89224790-195cfa80-d5a7-11ea-876b-14bd9856e66a.gif)
