### PR TITLE
Drag and drop to move model

### DIFF
--- a/src/interface/ModelsSidebar.js
+++ b/src/interface/ModelsSidebar.js
@@ -100,7 +100,6 @@ class ModelsSidebar {
 				type: 'model-file',
 				fullPath,
 			}));
-			console.log('dragstart dataTransfer.items.length', event.originalEvent.dataTransfer.items.length)
 		});
 
 	}

--- a/src/managers/ModelsManager.js
+++ b/src/managers/ModelsManager.js
@@ -46,6 +46,31 @@ class ModelsManager {
 
 
 	/**
+	 * Move the given file in fullPath to the target directory.
+	 * @param {String} fullPath 
+	 * @param {String} target 
+	 * @returns {String} path of new file
+	 */
+	moveModel(fullPath, target) {
+		const fileName = path.basename(fullPath);
+		const targetPath = path.join(target, fileName);
+
+		// Only do stuff if moving to a different directory.
+		if (fullPath !== targetPath) {
+			// If this file was selected, then update the path to it.
+			if (this.selected === fullPath) {
+				this.selected = targetPath;
+				G.modelsManager.setLastOpened();
+			}
+
+			G.io.renameFile(fullPath, targetPath);
+			G.modelsManager.update();
+		}
+		return targetPath;
+	}
+
+
+	/**
 	 * Rename the given file in fullPath to the newName
 	 * @param {String} fullPath Full path to file like /Users/demo/cogulator/filename.goms
 	 * @param {String} newName New name for file without extension like new_filename

--- a/src/style/sidebar.css
+++ b/src/style/sidebar.css
@@ -1,4 +1,4 @@
-.directory_label {
+.directory_label, .empty_directory_label{
 	font-family: 'Lato';
 	font-size: 17px;
 	position: relative;
@@ -12,6 +12,10 @@
     cursor:default;
 	user-select: none;
 	color:var(--directory-txt-color);
+}
+
+.directory_label.dragging {
+	background-color: var(--border-color);
 }
 
 .model_button{


### PR DESCRIPTION
Drag and drop a model to move it to another folder...

Currently highlights the folder you are dopping with `--border-color` but that styling can be changed easily.

Supports moving the currently selected model as well.

Slightly changed the "blank" directory label at the bottom of the list to empty_directory_label so you can't drag to that one.

![cogulator-move-model](https://user-images.githubusercontent.com/173666/90918112-1c7f2580-e3b2-11ea-96e9-18f1388385a2.gif)

