### PR TITLE
Added context menu for models and directories in sidebar (and some bug fixes)

### DIFF
--- a/src/managers/FirstRunManager.js
+++ b/src/managers/FirstRunManager.js
@@ -25,7 +25,7 @@
 class FirstRunManager {
 
 	constructor() {
-		if (G.io.fileExists(G.paths.cogulator)) {
+		if (G.io.pathExists(G.paths.cogulator)) {
 			G.startUp.load();
 		} else { 
 			G.helpScreen.show();

--- a/src/managers/InOutManager.js
+++ b/src/managers/InOutManager.js
@@ -54,19 +54,12 @@ class InOutManager {
 	}
 	
 
-	renameFile(sourcePth, targetPth) {
+	rename(sourcePth, targetPth) {
 		fs.renameSync(sourcePth, targetPth);
 	}
 	
 	
 	copyFile(sourcePth, targetPth, callback) {
-		console.log("COPY", sourcePth, targetPth);
-//		try {
-//			fs.createReadStream(sourcePth).pipe(fs.createWriteStream(targetPth));
-//		} catch(err) {
-//			dialog.showErrorBox("Could not copy file.", "Could not copy file at " + sourcePth + ". Either the file does not exist or permissions do not allow for it to be opened.");
-//		}
-		
 		try {
 			const BUF_LENGTH = 64*1024;
 			const buff = new Buffer(BUF_LENGTH);
@@ -93,7 +86,7 @@ class InOutManager {
 	
 	//Only handles one directory level down right now
 	newFile(pth, filename, text, callback) {
-		if (!this.fileExists(pth)) fs.mkdirSync(pth);
+		if (!this.pathExists(pth)) fs.mkdirSync(pth);
 		
 		let fullPath = path.join(pth, filename);
 		
@@ -111,7 +104,7 @@ class InOutManager {
 	
 	
 	newDirectory(pth) {
-		if (!this.fileExists(pth)) fs.mkdirSync(pth);
+		if (!this.pathExists(pth)) fs.mkdirSync(pth);
 	}
 	
 	
@@ -123,7 +116,7 @@ class InOutManager {
 			dialog.showErrorBox("Could not save.", "Could not save file at " + pth + ". This can be caused by permissions that do not allow for writing the file.");
 		}
 		
-		if (typeof callback === 'function' && callback()) callback();
+		if (typeof callback === 'function') callback();
 	}
 	
 	
@@ -138,14 +131,14 @@ class InOutManager {
 	}
 	
 	
-	deleteFile(pth, callback = 0) {
+	delete(pth, callback = 0) {
 		trash(pth).then(() => {
-			if (typeof callback === 'function' && callback()) callback();
+			if (typeof callback === 'function') callback();
 		});
 	}
 	
 	
-	fileExists(pth) {
+	pathExists(pth) {
 		if (fs.existsSync(pth)) return true;
 		return false;
 	}

--- a/src/style/sidebar.css
+++ b/src/style/sidebar.css
@@ -1,7 +1,6 @@
 .directory_label, .empty_directory_label{
 	font-family: 'Lato';
 	font-size: 17px;
-	width:100%;
 	height:40px;
 	line-height: 40px;
 	font-family: 'Lato';
@@ -24,6 +23,7 @@
 
 .directory_label .button {
 	flex-grow: 0;
+	flex-shrink: 0;
 	width: 18px;
 	padding: 0 0 0 10px;
 	font-size: 11px;
@@ -47,6 +47,7 @@
 }
 
 .model_button_delete, .model_button_undo {
+	flex-shrink: 0;
 	text-align: center;
 	width:20px;
 	line-height:26px;
@@ -57,18 +58,27 @@
 	line-height: 26px;
 }
 
-input[type=text].rename_model {
+input[type=text].rename {
 	flex-grow: 1;
 	background: white;
 	font-family: 'Lato-Regular';
 	padding: 0 5px; 
+	width: 50px;
 	margin-right: 5px;
 	align-self: stretch;
 	border: none;
 }
 
-input[type=text].rename_model:focus {
+input[type=text].rename:focus {
 	outline-width: unset;
+}
+
+.model_button input[type=text].rename {
+	font-size: 14px;
+}
+
+.directory_label input[type=text].rename {
+	font-size: 17px;
 }
 
 .strikethrough {


### PR DESCRIPTION
Video of new functionality:

![context-menu](https://user-images.githubusercontent.com/173666/93603489-115bed00-f992-11ea-959c-ca0acdff024c.gif)

Major Updates
=============

* Right click on directory for context menu:
  * Rename Directory
  * Delete Directory
* Right click on model for context menu:
  * Duplicate Model
  * Rename Model
  * Delete Model
* Double click on directory to rename

Minor Updates/Bug Fixes
=======================

* Cleaned up/fixed some styles.
* Added a check to renaming models and directories to append a number if the file already exists.
* Added a check to renaming models and directories to not do anything if you leave the input field blank.
* Moved some functionality from `buildSideBar` to new `enableDirectoryActions` `enableModelActions` methods to keep code cleaner
* Fixed spelling of `enableModelDragDrop` and moved it inside `buildSideBar`.
* Fixed an issue with calling `​G.modelsManager.loadModel`​ from within `​G.modelsSidebar.showSelected`​. This would result in `showSelected` getting called twice.
* Fixed an issue in `InOutManager.js` where callbacks could get called twice.
* Renamed a few functions in `​InOutManager.js`​ since they are now used for models and directories:
  * `renameFile` -\> `rename`
  * `deleteFile` -\> `delete`
  * `fileExists` -\> `pathExists`